### PR TITLE
Fix crash when reloadData is called & number of items increases

### DIFF
--- a/AKPickerViewSample/AKPickerView/AKPickerView.m
+++ b/AKPickerViewSample/AKPickerView/AKPickerView.m
@@ -99,6 +99,7 @@
 
 - (void)reloadData
 {
+    [self.collectionView.collectionViewLayout invalidateLayout];
 	[self.collectionView reloadData];
 }
 


### PR DESCRIPTION
Use case — have an array of 10 strings, setup picker view, then create a new array with 20 strings and call `-reloadData` method. It'll crash, trying to reach an object beyond array's bounds. Adding collection view layout invalidation in `-reloadData` method fixed this issue for me.

P.S. Thank you for this great class. 👍
