### PR TITLE
Fix issue when the selectedItem is greater than the new data source

### DIFF
--- a/AKPickerViewSample/AKPickerView/AKPickerView.m
+++ b/AKPickerViewSample/AKPickerView/AKPickerView.m
@@ -182,9 +182,13 @@
 	[self invalidateIntrinsicContentSize];
 	[self.collectionView.collectionViewLayout invalidateLayout];
 	[self.collectionView reloadData];
-	if ([self.dataSource numberOfItemsInPickerView:self]) {
-		[self selectItem:self.selectedItem animated:NO notifySelection:NO];
-	}
+    NSUInteger count = [self.dataSource numberOfItemsInPickerView:self];
+    if (count > 0 ) {
+        if (self.selectedItem >= count) {
+            _selectedItem = count - 1;
+        }
+        [self selectItem:self.selectedItem animated:NO notifySelection:NO];
+    }
 }
 
 - (CGFloat)offsetForItem:(NSUInteger)item


### PR DESCRIPTION
Supports I have an datasource with count is 10, and my selectedItem is 8. When I assign a new data source with count 5, it will crash. This PR fix this issue
